### PR TITLE
fix(emit): co-locate modifiers with test functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ contract FooTest {
         whenStuffCalled
     {
     }
-
 }");
 ```
 
@@ -96,7 +95,6 @@ contract FooTest {
         whenStuffCalled
     {
     }
-
 }
 ```
 
@@ -139,7 +137,6 @@ contract FooTest {
         // it should setup something
         // it should do something else
     }
-
 }
 ```
 */


### PR DESCRIPTION
Instead of emitting all the modifiers up front at the top of the contract, the changes from this PR will emit the co-located with the test functions where they are first used.

Closes https://github.com/alexfertel/bulloak/issues/9.