### PR TITLE
feat: add support for actions without parent conditions

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -397,7 +397,7 @@ impl<'s, T: Borrow<Tokenizer>> TokenizerI<'s, T> {
                 return Err(self.error(self.span(), ErrorKind::FileNameCharInvalid(self.char())));
             } else if self.peek().is_none() || self.peek().is_some_and(|c| c.is_whitespace()) {
                 lexeme.push(self.char());
-                let kind = match lexeme.to_ascii_lowercase().as_str() {
+                let kind = match lexeme.to_lowercase().as_str() {
                     "when" => TokenKind::When,
                     "it" => TokenKind::It,
                     "given" => TokenKind::Given,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,8 +6,40 @@ pub fn capitalize_first_letter(s: &str) -> String {
     }
 }
 
+pub fn lower_first_letter(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_lowercase().collect::<String>() + c.as_str(),
+    }
+}
+
 /// This functions makes the appropriate changes to a string to
 /// make it a valid identifier.
 pub fn sanitize(identifier: &str) -> String {
     identifier.replace('-', "_").replace(['\'', '"'], "")
+}
+
+/// Converts a sentence to pascal case.
+///
+/// The conversion is done by capitalizing the first letter of each word
+/// in the title and removing the spaces. For example, the sentence
+/// `when only owner` is converted to the `WhenOnlyOwner` string.
+pub fn to_pascal_case(sentence: &str) -> String {
+    sentence
+        .split_whitespace()
+        .map(capitalize_first_letter)
+        .collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_pascal_case;
+
+    #[test]
+    fn test_to_modifier() {
+        assert_eq!(to_pascal_case("when only owner"), "WhenOnlyOwner");
+        assert_eq!(to_pascal_case("when"), "When");
+        assert_eq!(to_pascal_case(""), "");
+    }
 }


### PR DESCRIPTION
This PR introduces one major change: adding support for actions without conditions. This is reflected in two areas:

- Remove the semantic check that every action needs a parent condition.
- Emit a test for each top-level action.

Closes https://github.com/alexfertel/bulloak/issues/22

### Considerations

We emit one test per top-level action. Even though this is inconsistent with how actions behave when they have parent conditions, I think it is less surprising, since actions without conditions suggest unrelated function invariants. This means that for the following `.tree`:

```
test.sol
├── it should match the output of a high-level hash
└── it should never revert
```

`bulloak` emits:

```solidity
pragma solidity 0.8.0;

contract TestTest {
  function test_MatchTheOutputOfAHigh_levelHash() external {
    // it should match the output of a high-level hash
  }

  function test_NeverRevert() external {
    // it should never revert
  }
}
```

Also, it's possible to interleave any number of actions and conditions. This enables testing function invariants & more specific scenarios using the same `.tree` file, instead of having to use two separate trees. This means that for the following `.tree`:

```
file.sol
└── it should do stuff
└── when something happens
    └── it should revert
└── it does everything
```

`bulloak` emits:

```solidity
pragma solidity 0.8.0;

contract FileTest {
  function test_DoStuff() external {
    // it should do stuff
  }

  modifier whenSomethingHappens() {
    _;
  }

  function test_RevertWhen_SomethingHappens()
    external
    whenSomethingHappens
  {
    // it should revert
  }

  function test_DoesEverything() external {
    // it does everything
  }
}
```
