### PR TITLE
fix: skip any comment in .tree files

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,19 +51,24 @@ pub(crate) fn pluralize<'a>(
     }
 }
 
-/// Splits the input text into distinct trees,
-/// delimited by two successive newlines.
+/// Splits the input text into distinct trees, delimited by two consecutive
+/// newlines.
 #[inline]
 pub(crate) fn split_trees(text: &str) -> Box<dyn Iterator<Item = &str> + '_> {
     if text.trim().is_empty() {
-        Box::new(std::iter::once(""))
-    } else {
-        Box::new(
-            text.split(TREES_SEPARATOR)
-                .map(str::trim)
-                .filter(|s| !s.is_empty()),
-        )
+        return Box::new(std::iter::once(""));
     }
+
+    let trees = text.split(TREES_SEPARATOR).map(str::trim);
+    let non_empty_trees = trees.filter(|s| !s.is_empty());
+    let no_isolated_comments =
+        non_empty_trees.filter(|tree| !only_comments(tree));
+
+    Box::new(no_isolated_comments)
+}
+
+fn only_comments(tree: &str) -> bool {
+    tree.lines().all(|l| l.trim().starts_with("//"))
 }
 
 #[cfg(test)]

--- a/tests/scaffold.rs
+++ b/tests/scaffold.rs
@@ -18,6 +18,7 @@ fn scaffolds_trees() {
         "removes_invalid_title_chars.tree",
         "hash_pair.tree",
         "revert_when.tree",
+        "spurious_comments.tree",
     ];
 
     for tree_name in trees {

--- a/tests/scaffold/spurious_comments.t.sol
+++ b/tests/scaffold/spurious_comments.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.0;
+
+contract HashPairTest {
+    function test_ShouldNeverRevert() external {
+        // It should never revert.
+    }
+
+    function test_WhenFirstArgIsSmallerThanSecondArg() external {
+        // It should match the result of `keccak256(abi.encodePacked(a,b))`.
+    }
+
+    function test_WhenFirstArgIsBiggerThanSecondArg() external {
+        // It should match the result of `keccak256(abi.encodePacked(b,a))`.
+    }
+}

--- a/tests/scaffold/spurious_comments.tree
+++ b/tests/scaffold/spurious_comments.tree
@@ -1,0 +1,12 @@
+// This comment doesn't work
+
+// This comment works
+HashPairTest
+├── It should never revert.  // This comment also works
+├── When first arg is smaller than second arg
+│   └── It should match the result of `keccak256(abi.encodePacked(a,b))`.
+└── When first arg is bigger than second arg
+    └── It should match the result of `keccak256(abi.encodePacked(b,a))`.
+// This comment works
+
+// This comment doesn't work


### PR DESCRIPTION
Resolves #75 