### PR TITLE
chore(docs): polish landing page wording & examples

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -44,7 +44,7 @@ const HeroSection = () => {
       <div className="relative z-10 text-center">
         <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold font-mono mb-4">bulloak</h1>
         <p className="text-lg sm:text-xl mb-8">
-          A Solidity test generator based on the Branching Tree Technique
+          A smart contract test generator based on the Branching Tree Technique
         </p>
         <Link href="https://github.com/alexfertel/bulloak" target="_blank" className="inline-flex items-center justify-center bg-slate-800 text-slate-100 px-4 sm:px-6 py-2 rounded-md hover:bg-slate-700 text-sm sm:text-base">
           <GitHubIcon className="w-4 h-4 mr-2" />
@@ -118,13 +118,13 @@ const BulloakFeaturesSection = () => {
           <code>{`
 Bulloak
 ├── Scaffold Command
-│   ├─── Generates Solidity test files from .tree specifications
+│   ├─── Generates test files from .tree specifications
 │   │   ├── Creates modifiers for conditions
 │   │   └── Generates test functions for actions
 │   ├─── Reports syntax errors in your specification
 │   └─── Provides a full AST for easy extension
 ├── Check Command
-│   ├── Ensures Solidity implementation matches its specification
+│   ├── Ensures implementation matches its specification
 │   ├── Reports missing tests
 │   └── Identifies structural mismatches
 ├── Multiple Tree Support
@@ -257,8 +257,8 @@ const Footer = () => {
             <h3 className="text-lg sm:text-xl font-bold mb-4">Resources/</h3>
             <ul>
               <li><span className="mr-2">├──</span><Link href="https://github.com/PaulRBerg/btt-examples" target="_blank" className="hover:underline hover:text-slate-600">BTT examples</Link></li>
-              <li><span className="mr-2">├──</span><Link href="https://youtu.be/V6KBy8QQnCo" target="_blank" className="hover:underline hover:text-slate-600">EthCC[6]Paul Berg&apos;s presentation at EthCC[6]</Link></li>
-              <li><span className="mr-2">├──</span><Link href="https://youtu.be/0-EmbNVgFA4" target="_blank" className="hover:underline hover:text-slate-600">Paul Berg&apos;s presentation at at Solidity Summit</Link></li>
+              <li><span className="mr-2">├──</span><Link href="https://youtu.be/V6KBy8QQnCo" target="_blank" className="hover:underline hover:text-slate-600">Paul Berg&apos;s presentation at EthCC[6]</Link></li>
+              <li><span className="mr-2">├──</span><Link href="https://youtu.be/0-EmbNVgFA4" target="_blank" className="hover:underline hover:text-slate-600">Paul Berg&apos;s presentation at Solidity Summit</Link></li>
               <li><span className="mr-2">├──</span><Link href="https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator" target="_blank" className="hover:underline hover:text-slate-600">Ascii Tree Generator for VSCode</Link></li>
               <li><span className="mr-2">└──</span><Link href="https://marketplace.visualstudio.com/items?itemName=PraneshASP.vscode-solidity-inspector" className="hover:underline hover:text-slate-600">Syntax highlighting for tree files for VSCode</Link></li>
             </ul>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -44,7 +44,7 @@ const HeroSection = () => {
       <div className="relative z-10 text-center">
         <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold font-mono mb-4">bulloak</h1>
         <p className="text-lg sm:text-xl mb-8">
-          A test generator based on the Branching Tree Technique
+          A Solidity test generator based on the Branching Tree Technique
         </p>
         <Link href="https://github.com/alexfertel/bulloak" target="_blank" className="inline-flex items-center justify-center bg-slate-800 text-slate-100 px-4 sm:px-6 py-2 rounded-md hover:bg-slate-700 text-sm sm:text-base">
           <GitHubIcon className="w-4 h-4 mr-2" />
@@ -77,7 +77,6 @@ const BTTExplanationSection = () => {
             <h3 className="text-lg sm:text-xl font-bold mb-4">Example BTT Structure</h3>
             <pre className="text-xs sm:text-sm font-mono overflow-x-auto">
               {`HashPairTest
-├── It should never revert.
 ├── When first arg is smaller than second arg
 │   └── It should match the result of keccak256(a,b).
 └── When first arg is bigger than second arg
@@ -112,26 +111,26 @@ const BulloakFeaturesSection = () => {
         <p className="text-base sm:text-lg mb-6">
           bulloak is a powerful tool that brings the Branching Tree Technique to life for developers. It automates the process of creating comprehensive test suites based on BTT specifications.
           {" "}<Link href="https://github.com/alexfertel/bulloak" target="_blank" className="inline-flex text-base sm:text-lg font-bold underline hover:text-slate-600">
-            Read the full README on GitHub.
+            Check out the full README on GitHub.
           </Link>
         </p>
         <pre className="text-sm sm:text-base font-mono overflow-x-auto mb-6 px-4 bg-slate-200 rounded">
           <code>{`
 Bulloak
 ├── Scaffold Command
-│   ├─── Automatically generates test files from .tree specifications
+│   ├─── Generates Solidity test files from .tree specifications
 │   │   ├── Creates modifiers for conditions
 │   │   └── Generates test functions for actions
 │   ├─── Reports syntax errors in your specification
 │   └─── Provides a full AST for easy extension
 ├── Check Command
-│   ├── Ensures code matches its specification
+│   ├── Ensures Solidity implementation matches its specification
 │   ├── Reports missing tests
 │   └── Identifies structural mismatches
 ├── Multiple Tree Support
 │   └── Define multiple test trees in a single file
 ├── Flexible Syntax
-│   ├── Supports 'when' and 'given' for conditions
+│   ├── Supports 'when' and 'given' for conditions and states, respectively
 │   └── Case-insensitive keywords
 └── Automatic Fixes
     ├── Adds missing functions
@@ -145,7 +144,6 @@ Bulloak
               <pre className="border border-slate-300 text-slate-900 px-4 overflow-x-auto text-xs sm:text-sm">
                 <code>{`
 HashPairTest
-├── It should never revert.
 ├── When first arg is smaller than second arg
 │   └── It should match the result of
 │       keccak256(abi.encodePacked(a,b)).
@@ -258,9 +256,9 @@ const Footer = () => {
           <div className="col-span-1">
             <h3 className="text-lg sm:text-xl font-bold mb-4">Resources/</h3>
             <ul>
-              <li><span className="mr-2">├──</span><Link href="https://www.youtube.com/watch?v=V6KBy8QQnCo" target="_blank" className="hover:underline hover:text-slate-600">Presentation by Paul R. Berg at EthCC[6]</Link></li>
-              <li><span className="mr-2">├──</span><Link href="https://www.youtube.com/watch?v=V6KBy8QQnCo" target="_blank" className="hover:underline hover:text-slate-600">Presentation by Paul R. Berg at Devconnect</Link></li>
               <li><span className="mr-2">├──</span><Link href="https://github.com/PaulRBerg/btt-examples" target="_blank" className="hover:underline hover:text-slate-600">BTT examples</Link></li>
+              <li><span className="mr-2">├──</span><Link href="https://youtu.be/V6KBy8QQnCo" target="_blank" className="hover:underline hover:text-slate-600">EthCC[6]Paul Berg&apos;s presentation at EthCC[6]</Link></li>
+              <li><span className="mr-2">├──</span><Link href="https://youtu.be/0-EmbNVgFA4" target="_blank" className="hover:underline hover:text-slate-600">Paul Berg&apos;s presentation at at Solidity Summit</Link></li>
               <li><span className="mr-2">├──</span><Link href="https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator" target="_blank" className="hover:underline hover:text-slate-600">Ascii Tree Generator for VSCode</Link></li>
               <li><span className="mr-2">└──</span><Link href="https://marketplace.visualstudio.com/items?itemName=PraneshASP.vscode-solidity-inspector" className="hover:underline hover:text-slate-600">Syntax highlighting for tree files for VSCode</Link></li>
             </ul>
@@ -281,7 +279,7 @@ const Footer = () => {
           </div>
         </div>
         <div className="mt-10 sm:mt-12 text-xs sm:text-sm flex items-center justify-end">
-          Created by <Link href="https://alexfertel.me" target="_blank" className="ml-1 text-blue-600 hover:underline font-mono">alexfertel</Link>.
+          Created by <Link href="https://alexfertel.me" target="_blank" className="ml-1 text-blue-600 hover:underline font-mono">alexfertel</Link>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Feedback for the docs site.

I removed the `It should never revert` branch in order to provide a simpler, gentler example.