### PR TITLE
feat(bulloak): treat input files as globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "criterion",
  "figment",
  "forge-fmt",
+ "glob",
  "owo-colors",
  "pretty_assertions",
  "serde",
@@ -1258,9 +1259,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"

--- a/crates/bulloak/Cargo.toml
+++ b/crates/bulloak/Cargo.toml
@@ -22,6 +22,7 @@ figment.workspace = true
 forge-fmt.workspace = true
 owo-colors.workspace = true
 serde.workspace = true
+glob = "0.3.2"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/bulloak/src/check.rs
+++ b/crates/bulloak/src/check.rs
@@ -51,12 +51,14 @@ impl Check {
     ///
     /// Note that we don't deal with `solang_parser` errors at all.
     pub(crate) fn run(&self, cfg: &Cli) {
+        println!("hmmmmm");
         let mut specs = Vec::new();
         for pattern in &self.files {
             match expand_glob(pattern.clone()) {
                 Ok(iter) => specs.extend(iter),
                 Err(e) => eprintln!(
-                    "warn: could not expand {}: {}",
+                    "{}: could not expand {}: {}",
+                    "warn".yellow(),
                     pattern.display(),
                     e
                 ),

--- a/crates/bulloak/src/glob.rs
+++ b/crates/bulloak/src/glob.rs
@@ -71,4 +71,12 @@ mod tests {
             "backslash‐based glob must match forward‐slash one"
         );
     }
+
+    #[test]
+    fn invalid_pattern_returns_error() {
+        // Invalid glob syntax (unmatched '[') must return Err.
+        let bad = PathBuf::from("tests/scaffold/*[.tree");
+        let res = expand_glob(bad);
+        assert!(res.is_err(), "expected invalid glob to Err");
+    }
 }

--- a/crates/bulloak/src/glob.rs
+++ b/crates/bulloak/src/glob.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use glob::glob;
+
+pub(crate) fn expand_glob(
+    input: PathBuf,
+) -> anyhow::Result<impl Iterator<Item = PathBuf>> {
+    let input = input.to_string_lossy();
+    let paths = glob(&input)?.filter_map(Result::ok);
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::expand_glob;
+
+    /// Helper to collect and sort the output.
+    fn sorted_matches(pattern: &str) -> Vec<String> {
+        let mut v: Vec<_> = expand_glob(PathBuf::from(pattern))
+            .unwrap()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn literal_path_round_trips() {
+        // this crate has a Cargo.toml in its root
+        let out = sorted_matches("Cargo.toml");
+        assert_eq!(out, vec!["Cargo.toml".to_string()]);
+    }
+
+    #[test]
+    fn no_such_file_yields_empty() {
+        let out = sorted_matches("no-such-file-xyz.tree");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn simple_star_glob() {
+        // match all .rs files in src/
+        let out = sorted_matches("src/*.rs");
+        // at least main.rs must be there
+        assert!(out.iter().any(|e| e.ends_with("src/main.rs")));
+        // and check.rs too
+        assert!(out.iter().any(|e| e.ends_with("src/check.rs")));
+    }
+
+    #[test]
+    fn recursive_double_star_glob() {
+        // In your tests directory you have .tree files under tests/scaffold/
+        let out = sorted_matches("tests/scaffold/**/*.tree");
+        // A few smoke checks:
+        assert!(out.iter().any(|e| e.contains("tests/scaffold/basic.tree")));
+        assert!(out.iter().any(|e| e.contains("tests/scaffold/complex.tree")));
+    }
+
+    #[test]
+    fn forward_slash_glob_works_everywhere() {
+        let out = sorted_matches("tests/scaffold/*.tree");
+        assert!(out.iter().any(|e| e.ends_with("tests/scaffold/basic.tree")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn backslash_glob_works_the_same() {
+        let fwd = sorted_matches("tests/scaffold/*.tree");
+        let bwd = sorted_matches("tests\\scaffold\\*.tree");
+        assert_eq!(
+            fwd, bwd,
+            "backslash‐based glob must match forward‐slash one"
+        );
+    }
+}

--- a/crates/bulloak/src/glob.rs
+++ b/crates/bulloak/src/glob.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn literal_path_round_trips() {
-        // this crate has a Cargo.toml in its root
+        // This crate has a Cargo.toml in its root.
         let out = sorted_matches("Cargo.toml");
         assert_eq!(out, vec!["Cargo.toml".to_string()]);
     }
@@ -41,27 +41,24 @@ mod tests {
 
     #[test]
     fn simple_star_glob() {
-        // match all .rs files in src/
+        // Match all .rs files in src/
         let out = sorted_matches("src/*.rs");
-        // at least main.rs must be there
-        assert!(out.iter().any(|e| e.ends_with("src/main.rs")));
-        // and check.rs too
-        assert!(out.iter().any(|e| e.ends_with("src/check.rs")));
+        assert!(out.iter().any(|e| e.ends_with("main.rs")));
+        assert!(out.iter().any(|e| e.ends_with("check.rs")));
     }
 
     #[test]
     fn recursive_double_star_glob() {
-        // In your tests directory you have .tree files under tests/scaffold/
+        // `tests` directory has .tree files under tests/scaffold/.
         let out = sorted_matches("tests/scaffold/**/*.tree");
-        // A few smoke checks:
-        assert!(out.iter().any(|e| e.contains("tests/scaffold/basic.tree")));
-        assert!(out.iter().any(|e| e.contains("tests/scaffold/complex.tree")));
+        assert!(out.iter().any(|e| e.ends_with("basic.tree")));
+        assert!(out.iter().any(|e| e.ends_with("complex.tree")));
     }
 
     #[test]
     fn forward_slash_glob_works_everywhere() {
         let out = sorted_matches("tests/scaffold/*.tree");
-        assert!(out.iter().any(|e| e.ends_with("tests/scaffold/basic.tree")));
+        assert!(out.iter().any(|e| e.ends_with("basic.tree")));
     }
 
     #[test]

--- a/crates/bulloak/src/main.rs
+++ b/crates/bulloak/src/main.rs
@@ -3,6 +3,7 @@ use std::process;
 
 mod check;
 mod cli;
+mod glob;
 mod scaffold;
 
 fn main() {

--- a/crates/bulloak/src/scaffold.rs
+++ b/crates/bulloak/src/scaffold.rs
@@ -72,7 +72,8 @@ impl Scaffold {
                 Ok(iter) => files.extend(iter),
                 Err(e) => {
                     eprintln!(
-                        "warn: could not expand {}: {}",
+                        "{}: could not expand {}: {}",
+                        "warn".yellow(),
                         pattern.display(),
                         e
                     );

--- a/crates/bulloak/src/scaffold.rs
+++ b/crates/bulloak/src/scaffold.rs
@@ -13,7 +13,7 @@ use forge_fmt::fmt;
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 
-use crate::cli::Cli;
+use crate::{cli::Cli, glob::expand_glob};
 
 /// Generate Solidity tests based on your spec.
 #[doc(hidden)]
@@ -66,15 +66,28 @@ impl Scaffold {
     ///
     /// If any errors occur during processing, they are collected and reported.
     pub(crate) fn run(&self, cfg: &Cli) {
-        let errors: Vec<_> = self
-            .files
+        let mut files = Vec::with_capacity(self.files.len());
+        for pattern in &self.files {
+            match expand_glob(pattern.clone()) {
+                Ok(iter) => files.extend(iter),
+                Err(e) => {
+                    eprintln!(
+                        "warn: could not expand {}: {}",
+                        pattern.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        let errors = files
             .iter()
             .filter_map(|file| {
                 self.process_file(file, cfg)
                     .map_err(|e| (file.as_path(), e))
                     .err()
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         if !errors.is_empty() {
             Scaffold::report_errors(&errors);

--- a/crates/bulloak/tests/check.rs
+++ b/crates/bulloak/tests/check.rs
@@ -468,3 +468,34 @@ contract CancelTest {
     assert!(actual.contains(expected));
     assert!(actual.contains("4 issues fixed."));
 }
+
+/// If you pass an invalid glob to `bulloak check`,
+/// it should warn but still exit code = 0 and report “no issues found.”
+#[test]
+fn check_invalid_glob_warns_but_reports_success() {
+    let cwd = env::current_dir().unwrap();
+    let bin = common::get_binary_path();
+
+    let bad_glob = cwd.join("tests").join("check").join("*[.tree");
+    let out = cmd(&bin, "check", &bad_glob, &[]);
+
+    assert!(
+        out.status.success(),
+        "check should succeed even on invalid glob, got {:?}",
+        out
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("could not expand"),
+        "did not see warn on stderr: {}",
+        stderr
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("All checks completed successfully"),
+        "expected success message, got: {}",
+        stdout
+    );
+}

--- a/crates/bulloak/tests/common/mod.rs
+++ b/crates/bulloak/tests/common/mod.rs
@@ -14,6 +14,7 @@ pub(crate) fn get_binary_path() -> PathBuf {
 }
 
 /// Runs a command with the specified args.
+#[allow(dead_code)] // Not used in all test crates.
 pub(crate) fn cmd(
     binary_path: &PathBuf,
     command: &str,

--- a/crates/bulloak/tests/common/mod.rs
+++ b/crates/bulloak/tests/common/mod.rs
@@ -26,5 +26,5 @@ pub(crate) fn cmd(
         .arg(tree_path)
         .args(args)
         .output()
-        .expect("should execute the check command")
+        .expect("should execute the command")
 }

--- a/crates/bulloak/tests/glob_cmd.rs
+++ b/crates/bulloak/tests/glob_cmd.rs
@@ -1,0 +1,53 @@
+#![allow(missing_docs)]
+use std::{env, process::Command};
+
+mod common;
+
+#[test]
+fn scaffold_expands_glob_internally() {
+    let cwd = env::current_dir().unwrap();
+    let bin = common::get_binary_path();
+
+    // Build the pattern via PathBuf so it uses "\" on Windows.
+    let glob_pattern = cwd
+        .join("tests")
+        .join("scaffold")
+        .join("*.tree")
+        .to_string_lossy()
+        .to_string();
+
+    let out = Command::new(&bin)
+        .arg("scaffold")
+        .arg(&glob_pattern)
+        .output()
+        .expect("should run scaffold");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("contract HashPair"),);
+    assert!(stdout.contains("contract CancelTest"),);
+}
+
+#[test]
+fn check_expands_glob_internally() {
+    let cwd = env::current_dir().unwrap();
+    let bin = common::get_binary_path();
+
+    let glob_pattern = cwd
+        .join("tests")
+        .join("check")
+        .join("*.tree")
+        .to_string_lossy()
+        .to_string();
+
+    let out = Command::new(&bin)
+        .arg("check")
+        .arg(&glob_pattern)
+        .arg("-m")
+        .output()
+        .expect("should run check");
+    assert!(!out.status.success());
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("contract name mismatch"));
+    assert!(stderr.contains("contract name missing at tree root"));
+}

--- a/crates/bulloak/tests/glob_cmd.rs
+++ b/crates/bulloak/tests/glob_cmd.rs
@@ -27,6 +27,7 @@ fn scaffold_expands_glob_internally() {
     assert!(stdout.contains("contract CancelTest"),);
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn check_expands_glob_internally() {
     let cwd = env::current_dir().unwrap();

--- a/crates/bulloak/tests/glob_cmd.rs
+++ b/crates/bulloak/tests/glob_cmd.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
-use std::{env, process::Command};
+use common::cmd;
+use std::env;
 
 mod common;
 
@@ -9,18 +10,9 @@ fn scaffold_expands_glob_internally() {
     let bin = common::get_binary_path();
 
     // Build the pattern via PathBuf so it uses "\" on Windows.
-    let glob_pattern = cwd
-        .join("tests")
-        .join("scaffold")
-        .join("*.tree")
-        .to_string_lossy()
-        .to_string();
-
-    let out = Command::new(&bin)
-        .arg("scaffold")
-        .arg(&glob_pattern)
-        .output()
-        .expect("should run scaffold");
+    let glob_pattern = cwd.join("tests").join("scaffold").join("*.tree");
+    let out = cmd(&bin, "scaffold", &glob_pattern, &[]);
+    assert!(!out.status.success());
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("contract HashPair"),);
@@ -33,19 +25,8 @@ fn check_expands_glob_internally() {
     let cwd = env::current_dir().unwrap();
     let bin = common::get_binary_path();
 
-    let glob_pattern = cwd
-        .join("tests")
-        .join("check")
-        .join("*.tree")
-        .to_string_lossy()
-        .to_string();
-
-    let out = Command::new(&bin)
-        .arg("check")
-        .arg(&glob_pattern)
-        .arg("-m")
-        .output()
-        .expect("should run check");
+    let glob_pattern = cwd.join("tests").join("check").join("*.tree");
+    let out = cmd(&bin, "check", &glob_pattern, &[]);
     assert!(!out.status.success());
 
     let stderr = String::from_utf8_lossy(&out.stderr);

--- a/crates/bulloak/tests/glob_cmd.rs
+++ b/crates/bulloak/tests/glob_cmd.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
-use common::cmd;
 use std::env;
+
+use common::cmd;
 
 mod common;
 

--- a/crates/bulloak/tests/scaffold.rs
+++ b/crates/bulloak/tests/scaffold.rs
@@ -160,3 +160,35 @@ fn errors_when_root_contract_identifier_is_missing_multiple_roots() {
         assert!(actual.contains("contract name missing at tree root #1"));
     }
 }
+
+/// If you pass an invalid glob to `bulloak scaffold`,
+/// it should warn but still exit code = 0 and produce no contract.
+#[test]
+fn scaffold_invalid_glob_warns_but_no_output() {
+    let cwd = env::current_dir().unwrap();
+    let bin = common::get_binary_path();
+
+    // Deliberately invalid glob (unmatched '[').
+    let bad_glob = cwd.join("tests").join("scaffold").join("*[.tree");
+    let out = cmd(&bin, "scaffold", &bad_glob, &[]);
+
+    assert!(
+        out.status.success(),
+        "scaffold should succeed even on invalid glob, got {:?}",
+        out
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("could not expand"),
+        "did not see the expected warn: {}",
+        stderr
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("contract "),
+        "unexpected scaffold output: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
Closes https://github.com/alexfertel/bulloak/issues/97

The idea is that bulloak now pre-processes input files as globs so that it works regardless of the shell supporting expanding globs or not.