### PR TITLE
fix: add underscore between function name and test name for multiple roots

### DIFF
--- a/crates/bulloak/tests/scaffold/hash_pair.t.sol
+++ b/crates/bulloak/tests/scaffold/hash_pair.t.sol
@@ -2,39 +2,39 @@
 pragma solidity 0.8.0;
 
 contract Utils {
-    function test_HashPairShouldNeverRevert() external {
+    function test_HashPair_ShouldNeverRevert() external {
         // It should never revert.
     }
 
-    function test_HashPairWhenFirstArgIsSmallerThanSecondArg() external {
+    function test_HashPair_WhenFirstArgIsSmallerThanSecondArg() external {
         // It should match the result of `keccak256(abi.encodePacked(a,b))`.
     }
 
-    function test_HashPairWhenFirstArgIsBiggerThanSecondArg() external {
+    function test_HashPair_WhenFirstArgIsBiggerThanSecondArg() external {
         // It should match the result of `keccak256(abi.encodePacked(b,a))`.
     }
 
-    function test_MinShouldNeverRevert() external {
+    function test_Min_ShouldNeverRevert() external {
         // It should never revert.
     }
 
-    function test_MinWhenFirstArgIsSmallerThanSecondArg() external {
+    function test_Min_WhenFirstArgIsSmallerThanSecondArg() external {
         // It should match the value of `a`.
     }
 
-    function test_MinWhenFirstArgIsBiggerThanSecondArg() external {
+    function test_Min_WhenFirstArgIsBiggerThanSecondArg() external {
         // It should match the value of `b`.
     }
 
-    function test_MaxShouldNeverRevert() external {
+    function test_Max_ShouldNeverRevert() external {
         // It should never revert.
     }
 
-    function test_MaxWhenFirstArgIsSmallerThanSecondArg() external {
+    function test_Max_WhenFirstArgIsSmallerThanSecondArg() external {
         // It should match the value of `b`.
     }
 
-    function test_MaxWhenFirstArgIsBiggerThanSecondArg() external {
+    function test_Max_WhenFirstArgIsBiggerThanSecondArg() external {
         // It should match the value of `a`.
     }
 }

--- a/crates/bulloak/tests/scaffold/multiple_roots.t.sol
+++ b/crates/bulloak/tests/scaffold/multiple_roots.t.sol
@@ -2,15 +2,19 @@
 pragma solidity 0.8.0;
 
 contract MultipleRootsTreeTest {
-    function test_Function1ShouldNeverRevert() external {
+    function test_Function1_ShouldNeverRevert() external {
         // It should never revert.
     }
 
-    function test_Function1WhenFirstArgIsBiggerThanSecondArg() external {
+    function test_Function1_WhenFirstArgIsBiggerThanSecondArg() external {
         // It is all good
     }
 
-    function test_Function2WhenStuffHappens() external {
-        // It should do something simple
+    function test_Function2_RevertWhen_StuffDoesNotHappen() external {
+        // it should revert
+    }
+
+    function test_Function2_WhenStuffHappens() external {
+        // it should do something simple
     }
 }

--- a/crates/bulloak/tests/scaffold/multiple_roots.tree
+++ b/crates/bulloak/tests/scaffold/multiple_roots.tree
@@ -4,5 +4,7 @@ MultipleRootsTreeTest::function1
     └── It is all good
 
 MultipleRootsTreeTest::function2
-└── When stuff happens
-    └── It should do something simple
+├── when stuff does not happen
+│   └── it should revert
+└── when stuff happens
+    └── it should do something simple

--- a/crates/bulloak/tests/scaffold/multiple_roots_vm_skip.t.sol
+++ b/crates/bulloak/tests/scaffold/multiple_roots_vm_skip.t.sol
@@ -4,18 +4,23 @@ pragma solidity 0.8.0;
 import {Test} from "forge-std/Test.sol";
 
 contract MultipleRootsTreeTest is Test {
-    function test_Function1ShouldNeverRevert() external {
+    function test_Function1_ShouldNeverRevert() external {
         // It should never revert.
         vm.skip(true);
     }
 
-    function test_Function1WhenFirstArgIsBiggerThanSecondArg() external {
+    function test_Function1_WhenFirstArgIsBiggerThanSecondArg() external {
         // It is all good
         vm.skip(true);
     }
 
-    function test_Function2WhenStuffHappens() external {
-        // It should do something simple
+    function test_Function2_RevertWhen_StuffDoesNotHappen() external {
+        // it should revert
+        vm.skip(true);
+    }
+
+    function test_Function2_WhenStuffHappens() external {
+        // it should do something simple
         vm.skip(true);
     }
 }

--- a/crates/foundry/src/check/rules/structural_match.rs
+++ b/crates/foundry/src/check/rules/structural_match.rs
@@ -591,10 +591,10 @@ Foo::b
         let sol = r#"// SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.0;
 contract Foo {
-  function test_AA() external {
+  function test_A_A() external {
     // It A.
   }
-  function test_BB() external {
+  function test_B_B() external {
     // It B.
   }
 }

--- a/crates/foundry/src/hir/combiner.rs
+++ b/crates/foundry/src/hir/combiner.rs
@@ -233,7 +233,7 @@ fn update_children(
 fn prefix_test_with(test_name: &str, prefix: &str) -> String {
     let capitalized_fn_name = upper_first_letter(prefix);
     let test_suffix = test_name.trim_start_matches("test_");
-    format!("test_{capitalized_fn_name}{test_suffix}")
+    format!("test_{capitalized_fn_name}_{test_suffix}")
 }
 
 fn collect_modifier(
@@ -371,7 +371,7 @@ bulloak error: contract name missing at tree root #2";
                 "Contract".to_owned(),
                 vec![
                     function(
-                        "test_Function1RevertWhen_SomethingBadHappens"
+                        "test_Function1_RevertWhen_SomethingBadHappens"
                             .to_owned(),
                         hir::FunctionTy::Function,
                         Span::new(
@@ -385,7 +385,7 @@ bulloak error: contract name missing at tree root #2";
                         ])
                     ),
                     function(
-                        "test_Function2RevertWhen_SomethingShitHappens"
+                        "test_Function2_RevertWhen_SomethingShitHappens"
                             .to_owned(),
                         hir::FunctionTy::Function,
                         Span::new(
@@ -437,7 +437,7 @@ bulloak error: contract name missing at tree root #2";
                         None
                     ),
                     function(
-                        "test_Function1RevertGiven_SomethingElseHappens"
+                        "test_Function1_RevertGiven_SomethingElseHappens"
                             .to_owned(),
                         hir::FunctionTy::Function,
                         Span::new(
@@ -451,7 +451,7 @@ bulloak error: contract name missing at tree root #2";
                         ])
                     ),
                     function(
-                        "test_Function2RevertGiven_TheCallerIs0x1337"
+                        "test_Function2_RevertGiven_TheCallerIs0x1337"
                             .to_owned(),
                         hir::FunctionTy::Function,
                         Span::new(


### PR DESCRIPTION
### This PR addresses the following issues
- Closes https://github.com/alexfertel/bulloak/issues/105

### PR dependency
- https://github.com/alexfertel/bulloak/pull/102

### Changelog

This PR fixes the function names when multiple roots are present. A sample example can be found in the [issue description](https://github.com/alexfertel/bulloak/issues/105). I haven't touched the logic in case of collision when two or more branches have the same description since the fix implemented in https://github.com/alexfertel/bulloak/pull/102 needs to be updated. After that PR is merged, I can update this PR this PR to handle those cases.